### PR TITLE
Pin x402 SDK below 2.x to keep agentic client imports working.

### DIFF
--- a/agentic/requirements.txt
+++ b/agentic/requirements.txt
@@ -6,6 +6,6 @@ coinbase-agentkit==0.7.4
 requests
 python-dotenv
 web3>=6.0.0
-x402>=0.1.0
+x402>=0.1.0,<1.0
 httpx
 bedrock-agentcore


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
