### PR TITLE
feat: add A2A (Agent-to-Agent) x402 payment endpoint

### DIFF
--- a/agentic/a2a_router.py
+++ b/agentic/a2a_router.py
@@ -1,0 +1,233 @@
+"""
+A2A (Agent-to-Agent) x402 endpoint.
+
+Implements the two-leg handshake from
+  https://github.com/google-a2a/a2a-x402/v0.1
+
+Leg 1 - caller sends a message/send RPC without payment:
+  Server returns a task in state "input-required" with
+  x402.payment.required in the status message metadata.
+
+Leg 2 - caller resends the same task ID, this time with
+  x402.payment.status: "payment-submitted" and the signed
+  EIP-3009 payload in x402.payment.payload:
+  Server verifies payment, generates the image, settles,
+  and returns a completed task with the image artifact.
+
+Usage (from another agent):
+  POST /a2a
+  Content-Type: application/json
+  X-A2A-Extensions: https://github.com/google-a2a/a2a-x402/v0.1
+
+  {"jsonrpc":"2.0","id":"1","method":"message/send",
+   "params":{"message":{"kind":"message","role":"user",
+     "parts":[{"kind":"text","text":"a sunset over mountains"}]}}}
+"""
+
+import boto3
+import json
+import logging
+import os
+import uuid
+
+import requests as http_requests
+from fastapi import APIRouter
+from pydantic import BaseModel
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+NETWORK_TO_EIP155: Dict[str, str] = {
+    "base-sepolia": "eip155:84532",
+    "base": "eip155:8453",
+    "mainnet": "eip155:1",
+    "ethereum": "eip155:1",
+}
+
+# Nova Canvas fixed cost: $0.04 USDC (6-decimal wei)
+IMAGE_COST_WEI = int(0.04 * 1_000_000)
+
+bedrock = boto3.client(
+    "bedrock-runtime", region_name=os.getenv("AWS_REGION", "us-east-1")
+)
+
+
+def _build_task(task_id: str, state: str, parts: list, metadata: dict = None) -> dict:
+    task: Dict[str, Any] = {
+        "kind": "task",
+        "id": task_id,
+        "status": {
+            "state": state,
+            "message": {
+                "kind": "message",
+                "role": "agent",
+                "parts": parts,
+            },
+        },
+    }
+    if metadata:
+        task["status"]["message"]["metadata"] = metadata
+    return task
+
+
+def _facilitator_post(path: str, body: dict) -> dict:
+    resp = http_requests.post(
+        f"https://x402.org/facilitator/{path}",
+        json=body,
+        timeout=15,
+        allow_redirects=True,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _x402_body(payload: dict, requirements: dict) -> dict:
+    return {
+        "x402Version": 1,
+        "paymentPayload": {
+            "x402Version": 1,
+            "scheme": "exact",
+            "network": "base-sepolia",
+            "payload": payload,
+        },
+        "paymentRequirements": requirements,
+    }
+
+
+class A2ARequest(BaseModel):
+    jsonrpc: str
+    id: Any = None
+    method: str
+    params: Dict[str, Any]
+
+
+@router.post("/a2a")
+async def a2a_message_send(request: A2ARequest):
+    """JSON-RPC endpoint for A2A message/send with x402 payment handshake."""
+    if request.method != "message/send":
+        return {
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "error": {"code": -32601, "message": f"Method not found: {request.method}"},
+        }
+
+    message = request.params.get("message", {})
+    task_id = message.get("taskId") or str(uuid.uuid4())
+    metadata = message.get("metadata", {})
+    parts = message.get("parts", [])
+    prompt = next(
+        (p.get("text", "") for p in parts if p.get("kind") == "text"), ""
+    ) or "A beautiful AI-generated image"
+
+    gateway_url = os.getenv("GATEWAY_URL", "").rstrip("/")
+    seller_wallet = os.getenv("SELLER_WALLET", "")
+    raw_network = os.getenv("NETWORK_ID", "base-sepolia")
+    eip155_network = NETWORK_TO_EIP155.get(raw_network, "eip155:84532")
+    usdc_contract = os.getenv("USDC_CONTRACT", "0x036CbD53842c5426634e7929541eC2318f3dCF7e")
+
+    payment_requirements = {
+        "scheme": "exact",
+        "network": eip155_network,
+        "amount": str(IMAGE_COST_WEI),
+        "asset": usdc_contract,
+        "payTo": seller_wallet,
+        "maxTimeoutSeconds": 600,
+        "extra": {"name": "USDC", "version": "2", "decimals": 6},
+    }
+
+    # Leg 1: no payment yet
+    if metadata.get("x402.payment.status") != "payment-submitted":
+        task = _build_task(
+            task_id,
+            "input-required",
+            [{"kind": "text", "text": "Payment required to generate image."}],
+            metadata={
+                "x402.payment.status": "payment-required",
+                "x402.payment.required": {
+                    "x402Version": 2,
+                    "error": "Payment required",
+                    "resource": {
+                        "url": f"{gateway_url}/a2a",
+                        "description": "AI image generation via Amazon Nova Canvas",
+                        "mimeType": "application/json",
+                    },
+                    "accepts": [payment_requirements],
+                },
+            },
+        )
+        return {"jsonrpc": "2.0", "id": request.id, "result": task}
+
+    # Leg 2: payment submitted
+    payment_payload_raw = metadata.get("x402.payment.payload", {})
+    actual_payload = payment_payload_raw.get("payload", payment_payload_raw)
+
+    try:
+        verification = _facilitator_post("verify", _x402_body(actual_payload, payment_requirements))
+    except Exception as exc:
+        logger.error("x402 verify error: %s", exc)
+        return {
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": _build_task(task_id, "failed",
+                [{"kind": "text", "text": f"Payment verification error: {exc}"}],
+                metadata={"x402.payment.status": "payment-failed", "x402.payment.error": str(exc)}),
+        }
+
+    if not verification.get("isValid"):
+        reason = verification.get("invalidReason", "unknown")
+        return {
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": _build_task(task_id, "failed",
+                [{"kind": "text", "text": f"Invalid payment: {reason}"}],
+                metadata={"x402.payment.status": "payment-failed", "x402.payment.error": reason}),
+        }
+
+    # Generate image — settle only if generation succeeds (fair billing)
+    try:
+        br_response = bedrock.invoke_model(
+            modelId="amazon.nova-canvas-v1:0",
+            body=json.dumps({
+                "taskType": "TEXT_IMAGE",
+                "textToImageParams": {"text": prompt},
+                "imageGenerationConfig": {"numberOfImages": 1, "quality": "standard", "height": 1024, "width": 1024},
+            }),
+        )
+        image_b64: str = json.loads(br_response["body"].read())["images"][0]
+    except Exception as exc:
+        logger.error("Bedrock generation failed: %s", exc)
+        return {
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": _build_task(task_id, "failed",
+                [{"kind": "text", "text": "Image generation failed — payment not charged."}],
+                metadata={"x402.payment.status": "payment-accepted", "x402.payment.error": f"generation_failed: {exc}", "x402.payment.receipts": []}),
+        }
+
+    receipts = []
+    try:
+        settlement = _facilitator_post("settle", _x402_body(actual_payload, payment_requirements))
+        receipts.append({"success": settlement.get("success", False), "transaction": settlement.get("transaction"), "network": eip155_network})
+    except Exception as exc:
+        receipts.append({"success": False, "errorReason": str(exc), "network": eip155_network})
+
+    artifact_id = str(uuid.uuid4())
+    task = _build_task(
+        task_id, "completed",
+        [{"kind": "text", "text": f"Image generated: {prompt[:80]}"}],
+        metadata={
+            "x402.payment.status": "payment-settled",
+            "x402.payment.receipts": receipts,
+            "x402.payment.lifecycle": ["payment-required", "payment-submitted", "payment-accepted", "payment-settled"],
+        },
+    )
+    task["artifacts"] = [{
+        "artifactId": artifact_id,
+        "name": "generated-image.png",
+        "description": f"Nova Canvas image: {prompt[:80]}",
+        "mimeType": "image/png",
+        "data": image_b64,
+    }]
+    return {"jsonrpc": "2.0", "id": request.id, "result": task}

--- a/agentic/agent.py
+++ b/agentic/agent.py
@@ -8,11 +8,13 @@ from tools import estimate_image_cost, check_wallet_balance, make_payment, gener
 from memory_hook import MemoryHook, MEMORY_ID
 import os
 import logging
+from a2a_router import router as a2a_router
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 
 app = FastAPI(title="Content Monetization Agent", version="1.0.0")
+app.include_router(a2a_router)
 
 model = BedrockModel(
     model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",

--- a/serverless/lambda/a2a/a2a.js
+++ b/serverless/lambda/a2a/a2a.js
@@ -1,0 +1,185 @@
+import { Hono } from 'hono';
+import { handle } from 'hono/aws-lambda';
+import https from 'https';
+import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
+
+const app = new Hono();
+const lambda = new LambdaClient({ region: process.env.AWS_REGION || 'us-east-1' });
+
+const X402_CONFIG = {
+  usdcBase: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+  network: 'base-sepolia',
+  scheme: 'exact',
+};
+
+const IMAGE_COST_WEI = String(0.04 * 1_000_000 | 0); // $0.04 USDC in 6-decimal wei
+
+const NETWORK_TO_EIP155 = {
+  'base-sepolia': 'eip155:84532',
+  'base': 'eip155:8453',
+  'mainnet': 'eip155:1',
+};
+
+app.use('*', async (c, next) => {
+  c.header('Access-Control-Allow-Origin', '*');
+  c.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  c.header('Access-Control-Allow-Headers', 'Content-Type, X-A2A-Extensions');
+  if (c.req.method === 'OPTIONS') return c.text('', 200);
+  await next();
+});
+
+function buildTask(taskId, state, parts, metadata) {
+  const task = {
+    kind: 'task',
+    id: taskId,
+    status: {
+      state,
+      message: { kind: 'message', role: 'agent', parts },
+    },
+  };
+  if (metadata) task.status.message.metadata = metadata;
+  return task;
+}
+
+async function facilitatorPost(path, body) {
+  const bodyString = JSON.stringify(body);
+  return new Promise((resolve, reject) => {
+    const makeRequest = (url) => {
+      const parsedUrl = new URL(url);
+      const req = https.request({
+        hostname: parsedUrl.hostname, port: parsedUrl.port || 443, path: parsedUrl.pathname,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(bodyString) },
+      }, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) return makeRequest(res.headers.location);
+        let data = '';
+        res.on('data', (chunk) => data += chunk);
+        res.on('end', () => { try { resolve(JSON.parse(data)); } catch (e) { reject(new Error(`Parse error: ${data}`)); } });
+      });
+      req.on('error', reject);
+      req.write(bodyString);
+      req.end();
+    };
+    makeRequest(`https://x402.org/facilitator/${path}`);
+  });
+}
+
+async function invokeBedrockLambda(prompt) {
+  const payload = JSON.stringify({ action: 'generate_image', prompt });
+  const response = await lambda.send(new InvokeCommand({
+    FunctionName: process.env.BEDROCK_LAMBDA_ARN,
+    Payload: Buffer.from(payload),
+  }));
+  const result = JSON.parse(Buffer.from(response.Payload).toString());
+  if (result.errorMessage) throw new Error(result.errorMessage);
+  return result.image_b64 || result.imageBase64 || result.image;
+}
+
+app.post('/a2a', async (c) => {
+  let body;
+  try { body = await c.req.json(); } catch { return c.json({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } }); }
+
+  const { jsonrpc, id, method, params } = body;
+  if (method !== 'message/send') {
+    return c.json({ jsonrpc: '2.0', id, error: { code: -32601, message: `Method not found: ${method}` } });
+  }
+
+  const message = params?.message || {};
+  const taskId = message.taskId || crypto.randomUUID();
+  const metadata = message.metadata || {};
+  const parts = message.parts || [];
+  const prompt = parts.find(p => p.kind === 'text')?.text || 'A beautiful AI-generated image';
+
+  const gatewayUrl = (process.env.GATEWAY_URL || 'https://example.com').replace(/\/$/, '');
+  const sellerWallet = process.env.SELLER_WALLET || '';
+  const rawNetwork = process.env.NETWORK_ID || 'base-sepolia';
+  const eip155Network = NETWORK_TO_EIP155[rawNetwork] || 'eip155:84532';
+  const usdcContract = process.env.USDC_CONTRACT || X402_CONFIG.usdcBase;
+
+  const paymentRequirements = {
+    scheme: 'exact',
+    network: eip155Network,
+    amount: IMAGE_COST_WEI,
+    asset: usdcContract,
+    payTo: sellerWallet,
+    maxTimeoutSeconds: 600,
+    extra: { name: 'USDC', version: '2', decimals: 6 },
+  };
+
+  // Leg 1 — no payment yet
+  if (metadata['x402.payment.status'] !== 'payment-submitted') {
+    const task = buildTask(taskId, 'input-required',
+      [{ kind: 'text', text: 'Payment required to generate image.' }],
+      {
+        'x402.payment.status': 'payment-required',
+        'x402.payment.required': {
+          x402Version: 2, error: 'Payment required',
+          resource: { url: `${gatewayUrl}/a2a`, description: 'AI image generation via Amazon Nova Canvas', mimeType: 'application/json' },
+          accepts: [paymentRequirements],
+        },
+      });
+    return c.json({ jsonrpc: '2.0', id, result: task });
+  }
+
+  // Leg 2 — payment submitted
+  const paymentPayloadRaw = metadata['x402.payment.payload'] || {};
+  const actualPayload = paymentPayloadRaw.payload || paymentPayloadRaw;
+
+  const x402Body = {
+    x402Version: 1,
+    paymentPayload: { x402Version: 1, scheme: 'exact', network: 'base-sepolia', payload: actualPayload },
+    paymentRequirements,
+  };
+
+  let verification;
+  try { verification = await facilitatorPost('verify', x402Body); }
+  catch (err) {
+    return c.json({ jsonrpc: '2.0', id, result: buildTask(taskId, 'failed',
+      [{ kind: 'text', text: `Payment verification error: ${err.message}` }],
+      { 'x402.payment.status': 'payment-failed', 'x402.payment.error': err.message }) });
+  }
+
+  if (!verification.isValid) {
+    return c.json({ jsonrpc: '2.0', id, result: buildTask(taskId, 'failed',
+      [{ kind: 'text', text: `Invalid payment: ${verification.invalidReason}` }],
+      { 'x402.payment.status': 'payment-failed', 'x402.payment.error': verification.invalidReason }) });
+  }
+
+  // Generate image (settle only on success — fair billing)
+  let imageB64;
+  try { imageB64 = await invokeBedrockLambda(prompt); }
+  catch (err) {
+    return c.json({ jsonrpc: '2.0', id, result: buildTask(taskId, 'failed',
+      [{ kind: 'text', text: 'Image generation failed — payment not charged.' }],
+      { 'x402.payment.status': 'payment-accepted', 'x402.payment.error': `generation_failed: ${err.message}`, 'x402.payment.receipts': [] }) });
+  }
+
+  const receipts = [];
+  try {
+    const settlement = await facilitatorPost('settle', x402Body);
+    receipts.push({ success: !!settlement.success, transaction: settlement.transaction, network: eip155Network });
+  } catch (err) {
+    receipts.push({ success: false, errorReason: err.message, network: eip155Network });
+  }
+
+  const artifactId = crypto.randomUUID();
+  const task = buildTask(taskId, 'completed',
+    [{ kind: 'text', text: `Image generated: ${prompt.slice(0, 80)}` }],
+    {
+      'x402.payment.status': 'payment-settled',
+      'x402.payment.receipts': receipts,
+      'x402.payment.lifecycle': ['payment-required', 'payment-submitted', 'payment-accepted', 'payment-settled'],
+    });
+  task.artifacts = [{
+    artifactId,
+    name: 'generated-image.png',
+    description: `Nova Canvas image: ${prompt.slice(0, 80)}`,
+    mimeType: 'image/png',
+    data: imageB64,
+  }];
+  return c.json({ jsonrpc: '2.0', id, result: task });
+});
+
+app.get('/health', (c) => c.json({ status: 'healthy' }));
+
+export const handler = handle(app);

--- a/serverless/lib/ai-content-monetization-stack.ts
+++ b/serverless/lib/ai-content-monetization-stack.ts
@@ -55,6 +55,39 @@ export class AiContentMonetizationStack extends cdk.Stack {
       }
     });
 
+    // A2A Lambda — Agent-to-Agent x402 payment endpoint
+    const a2aLambda = new nodejs.NodejsFunction(this, 'A2ALambda', {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      entry: 'lambda/a2a/a2a.js',
+      handler: 'handler',
+      timeout: cdk.Duration.minutes(5),
+      memorySize: 512,
+      bundling: {
+        externalModules: ['aws-sdk']
+      },
+      environment: {
+        SELLER_WALLET: process.env.SELLER_WALLET_ADDRESS || '',
+        BEDROCK_LAMBDA_ARN: bedrockLambda.functionArn,
+        GATEWAY_URL: process.env.API_GATEWAY_HTTP_URL || '',
+        NETWORK_ID: process.env.NETWORK_ID || 'base-sepolia',
+        USDC_CONTRACT: process.env.USDC_CONTRACT || '0x036CbD53842c5426634e7929541eC2318f3dCF7e'
+      }
+    });
+
+    // Allow A2A Lambda to invoke Bedrock Lambda
+    a2aLambda.addToRolePolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['lambda:InvokeFunction'],
+      resources: [bedrockLambda.functionArn]
+    }));
+
+    // Allow A2A Lambda to call Bedrock directly
+    a2aLambda.addToRolePolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['bedrock:InvokeModel'],
+      resources: ['*']
+    }));
+
     // Bedrock permissions
     bedrockLambda.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
@@ -92,6 +125,7 @@ export class AiContentMonetizationStack extends cdk.Stack {
     // Lambda integrations
     const estimatorIntegration = new integrations.HttpLambdaIntegration('EstimatorIntegration', estimatorLambda);
     const sellerIntegration = new integrations.HttpLambdaIntegration('SellerIntegration', sellerLambda);
+    const a2aIntegration = new integrations.HttpLambdaIntegration('A2AIntegration', a2aLambda);
 
     // Routes
     httpApi.addRoutes({
@@ -110,6 +144,12 @@ export class AiContentMonetizationStack extends cdk.Stack {
       path: '/health',
       methods: [apigatewayv2.HttpMethod.GET],
       integration: sellerIntegration
+    });
+
+    httpApi.addRoutes({
+      path: '/a2a',
+      methods: [apigatewayv2.HttpMethod.POST],
+      integration: a2aIntegration
     });
 
     // S3 bucket for images with SSL enforcement


### PR DESCRIPTION
Implements the two-leg A2A x402 handshake so other agents can call and pay this service programmatically without a human in the loop.

Protocol: https://github.com/google-a2a/a2a-x402/v0.1
  POST /a2a  Content-Type: application/json
  Body: JSON-RPC { method: message/send, params: { message: {...} } }

Leg 1 — caller sends message without payment:
  Returns task state input-required with x402.payment.required in
  message metadata, advertising the USDC amount, contract, and payTo.

Leg 2 — caller re-sends with x402.payment.status: payment-submitted
  and the signed EIP-3009 authorization in x402.payment.payload:
  Verifies with x402.org facilitator, generates image via Nova Canvas,
  settles (deferred, only on success), returns completed task with
  image artifact and x402.payment.receipts.

The endpoint is framework-agnostic: any A2A-compliant caller that can sign USDC EIP-3009 authorizations can consume it without modifying the agent code.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
