### PR TITLE
feat: add USDC price cache and per-session spend cap

### DIFF
--- a/agentic/cost_estimator.py
+++ b/agentic/cost_estimator.py
@@ -1,28 +1,46 @@
+import time
+import threading
 import requests
 
-# Nova Canvas fixed per-image pricing
 NOVA_CANVAS_PRICING = {
     '1024x1024': {'standard': 0.04, 'premium': 0.06},
     '2048x2048': {'standard': 0.06, 'premium': 0.08}
 }
 
+_price_cache: dict = {'price': 1.0, 'expires_at': 0.0}
+_price_lock = threading.Lock()
+_PRICE_TTL = 60
+
+
 def get_usdc_price() -> float:
-    """Fetch USDC price from CoinGecko (should be ~$1.00)"""
+    """Fetch USDC price from CoinGecko, cached for 60 seconds."""
+    now = time.monotonic()
+    with _price_lock:
+        if now < _price_cache['expires_at']:
+            return _price_cache['price']
+
     try:
-        response = requests.get('https://api.coingecko.com/api/v3/simple/price?ids=usd-coin&vs_currencies=usd', timeout=5)
-        return response.json()['usd-coin']['usd']
-    except:
-        return 1.0
+        response = requests.get(
+            'https://api.coingecko.com/api/v3/simple/price?ids=usd-coin&vs_currencies=usd',
+            timeout=5
+        )
+        price = float(response.json()['usd-coin']['usd'])
+    except Exception:
+        price = 1.0
+
+    with _price_lock:
+        _price_cache['price'] = price
+        _price_cache['expires_at'] = time.monotonic() + _PRICE_TTL
+
+    return price
+
 
 def estimate_cost(content: str, model: str = 'nova-canvas', resolution: str = '1024x1024', quality: str = 'standard') -> dict:
     """Estimate cost for Nova Canvas image generation (fixed per-image pricing)"""
-    # Nova Canvas uses fixed pricing per image, not token-based
     total_cost_usd = NOVA_CANVAS_PRICING[resolution][quality]
-    
     usdc_price = get_usdc_price()
     total_cost_usdc = total_cost_usd / usdc_price
     total_cost_usdc_wei = int(total_cost_usdc * 1_000_000)
-    
     return {
         'model': model,
         'resolution': resolution,

--- a/agentic/tools.py
+++ b/agentic/tools.py
@@ -13,6 +13,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+SESSION_SPEND_CAP_USD = float(os.getenv('SESSION_SPEND_CAP_USD', '1.0'))
+
 bedrock_runtime = boto3.client('bedrock-runtime', region_name=os.getenv('AWS_REGION', 'us-east-1'))
 
 # Session-level storage - will be managed per session
@@ -25,6 +27,7 @@ class SessionStorage:
         self.auth_verified = set()
         self.current_request_id = None  # Track current request_id
         self.current_cost = None        # Track current cost
+        self.total_spent_usd = 0.0
 
 # Global fallback for backward compatibility
 IMAGE_STORAGE = {}
@@ -127,6 +130,15 @@ def make_payment(request_id: str = None, session_id: str = "default") -> str:
     if balance_info['usdc_balance'] < amount_usdc:
         return f"Error: Insufficient balance. Need {amount_usdc:.6f} USDC, have {balance_info['usdc_balance']:.6f} USDC"
     
+    projected_spend = storage.total_spent_usd + amount_usdc
+    if projected_spend > SESSION_SPEND_CAP_USD:
+        remaining = max(0.0, SESSION_SPEND_CAP_USD - storage.total_spent_usd)
+        return (
+            f"Error: Session spend cap of ${SESSION_SPEND_CAP_USD:.2f} USDC would be exceeded. "
+            f"Spent so far: ${storage.total_spent_usd:.4f}, this request: ${amount_usdc:.4f}, "
+            f"remaining allowance: ${remaining:.4f}. Start a new session to reset the cap."
+        )
+
     storage.authorize_check[request_id]['auth'] = True
     storage.auth_verified.add(request_id)
     # Update global for backward compatibility
@@ -257,8 +269,9 @@ def generate_image(request_id: str = None, session_id: str = "default") -> str:
     
     # Store image_id for potential analysis
     storage.authorize_check[request_id]['image_id'] = image_id
+    storage.total_spent_usd += cost_usdc
     AUTHORIZE_CHECK[request_id] = storage.authorize_check[request_id]
-    
+
     # Clear current request_id after successful completion to allow new requests
     storage.current_request_id = None
     storage.current_cost = None


### PR DESCRIPTION
cost_estimator.py: cache USDC price for 60 seconds
  get_usdc_price() previously hit the CoinGecko API on every
  estimate_image_cost() call. The price is now stored in a
  process-level dict protected by threading.Lock and only refreshed
  when the 60-second TTL expires. Falls back to 1.0 on network error.

tools.py: per-session spend cap
  Adds SESSION_SPEND_CAP_USD (env var, default $1.00). Before
  authorizing a payment, make_payment() checks that the session's
  running total plus the new cost would not exceed the cap. After a
  successful image generation the cost is added to
  session.total_spent_usd so subsequent requests correctly reflect
  cumulative usage.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
