### PR TITLE
fix(seller): retry x402 middleware setup instead of caching a failed or empty build

### DIFF
--- a/backend/lambdas/sellers/image-gen/index.js
+++ b/backend/lambdas/sellers/image-gen/index.js
@@ -73,29 +73,47 @@ app.use("*", async (c, next) => {
 // config, then cached for the life of the container. The provisioned wallet is
 // static per deploy, so capturing it once is safe — same reasoning as the
 // storefront's cached resource server.
+async function buildPaymentMiddleware() {
+  const sellerConfig = await getSellerConfig();
+  const accepts = buildAccepts(sellerConfig);
+  if (!accepts.length) {
+    // No provisioned seller wallet yet → no payment middleware. The route
+    // handler below returns a clear 503 so the caller knows to run Seller
+    // Setup, rather than getting an opaque x402 error.
+    return null;
+  }
+  const facilitatorClient = new HTTPFacilitatorClient({ url: X402_CONFIG.facilitatorUrl });
+  const server = new x402ResourceServer(facilitatorClient);
+  registerExactEvmScheme(server);
+  registerExactSvmScheme(server);
+  const httpServer = new x402HTTPResourceServer(server, { "POST /image-gen": { accepts } });
+  await httpServer.initialize(); // fetch /supported (feePayer, supported kinds)
+  return paymentMiddlewareFromHTTPServer(httpServer, undefined, undefined, false);
+}
+
+// Cache only a *successfully built* middleware. The in-flight promise is shared
+// so concurrent first requests don't each rebuild, but a null result (wallet
+// not provisioned yet) or a rejection (e.g. a transient x402 facilitator outage
+// during initialize()) is NOT cached: it clears the slot so the next request
+// retries. Caching those states would strand a warm container returning 503/500
+// for the rest of its life — even after Seller Setup runs or the facilitator
+// recovers — until an unrelated cold start.
 let _middlewarePromise = null;
 
 async function getPaymentMiddleware() {
   if (!_middlewarePromise) {
-    _middlewarePromise = (async () => {
-      const sellerConfig = await getSellerConfig();
-      const accepts = buildAccepts(sellerConfig);
-      if (!accepts.length) {
-        // No provisioned seller wallet yet → no payment middleware. The route
-        // handler below returns a clear 503 so the caller knows to run Seller
-        // Setup, rather than getting an opaque x402 error.
-        return null;
-      }
-      const facilitatorClient = new HTTPFacilitatorClient({ url: X402_CONFIG.facilitatorUrl });
-      const server = new x402ResourceServer(facilitatorClient);
-      registerExactEvmScheme(server);
-      registerExactSvmScheme(server);
-      const httpServer = new x402HTTPResourceServer(server, { "POST /image-gen": { accepts } });
-      await httpServer.initialize(); // fetch /supported (feePayer, supported kinds)
-      return paymentMiddlewareFromHTTPServer(httpServer, undefined, undefined, false);
-    })();
+    _middlewarePromise = buildPaymentMiddleware();
   }
-  return _middlewarePromise;
+  try {
+    const middleware = await _middlewarePromise;
+    if (!middleware) {
+      _middlewarePromise = null; // retry once the wallet is provisioned
+    }
+    return middleware;
+  } catch (err) {
+    _middlewarePromise = null; // retry after a transient build/facilitator failure
+    throw err;
+  }
 }
 
 app.use("/image-gen", async (c, next) => {


### PR DESCRIPTION
## Summary

In `backend/lambdas/sellers/image-gen/index.js`, `getPaymentMiddleware()` memoizes the middleware build promise unconditionally:

```js
if (!_middlewarePromise) {
  _middlewarePromise = (async () => { ... return null | middleware ... })();
}
return _middlewarePromise;
```

Two of the promise's outcomes are not safe to cache for the life of a warm Lambda container:

1. **Rejection.** `httpServer.initialize()` fetches `/supported` from the x402 facilitator. If that call fails (a transient facilitator outage, a cold-start network blip), the promise rejects and the rejected promise is cached. Every later request in that container then awaits the same rejected promise and returns 500, until an unrelated cold start, even after the facilitator recovers.
2. **`null` (no wallet yet).** If the first request arrives before Seller Setup provisions the payout wallet, `buildAccepts` returns `[]`, the build resolves to `null`, and that null is cached. The route keeps returning the 503 "Seller not configured" response for the life of the container even after Setup runs.

Both are self-inflicted stranding: the container gets stuck on the first outcome it happened to see.

## Fix

Cache only a successfully built middleware. Keep sharing the in-flight promise so concurrent first requests do not each rebuild, but clear the slot when the build resolves to `null` or rejects, so the next request retries.

```js
async function getPaymentMiddleware() {
  if (!_middlewarePromise) _middlewarePromise = buildPaymentMiddleware();
  try {
    const middleware = await _middlewarePromise;
    if (!middleware) _middlewarePromise = null; // retry once the wallet is provisioned
    return middleware;
  } catch (err) {
    _middlewarePromise = null; // retry after a transient build/facilitator failure
    throw err;
  }
}
```

A successfully built middleware is still cached for the life of the container, so the steady-state behavior is unchanged.

## Validation

Standalone reproduction of the caching wrappers (old vs new) against a build stub that fails once (facilitator down), then returns `null` (no wallet), then succeeds:

```
OLD -> req1..3 = [throw(500), throw(500), throw(500)] | req4 = throw(500) | total builds = 1
NEW -> req1..3 = [throw(500), null(503), REAL]        | req4 = REAL       | total builds = 3
```

`OLD` strands on its first outcome forever (one build, never retries). `NEW` retries after the transient failure and after Setup, then caches the successful middleware (build count stops at 3, so a successful build is still memoized and not rebuilt on later requests). `node --check` passes on the changed file.

Happy to add a unit test for `getPaymentMiddleware` if you would like one in the suite.
